### PR TITLE
added support for subdomain, client cert and replaced with indykite …

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -47,12 +47,19 @@ module "kubernetes" {
   eks_cluster                       = var.eks_cluster
   aws_region                        = var.aws_region
   hosted_zone                       = var.hosted_zone
+  root_domain                       = var.root_domain
+  is_root_domain                    = var.is_root_domain
   eks_node_role                     = var.eks_node_role
   aws_caller_identity_id            = data.aws_caller_identity.current.account_id
   aws_access_key_id                 = var.aws_access_key_id
   aws_secret_access_key             = var.aws_secret_access_key
   exclude_cluster_issuer            = var.exclude_cluster_issuer
   exclude_certificate               = var.exclude_certificate
+  use_client_cert                   = var.use_client_cert
+  client_cert_secret_name           = var.client_cert_secret_name
+  client_cert_file                  = var.client_cert_file
+  client_key_file                   = var.client_key_file
+
 
   shared_secret_OIDC_CLIENT_PWD      = random_password.shared_secret_OIDC_CLIENT_PWD.result
   shared_secret_INTERNAL_SECRET      = random_password.shared_secret_INTERNAL_SECRET.result

--- a/terraform/aws/modules/cypher/secret_generate.tf
+++ b/terraform/aws/modules/cypher/secret_generate.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "run_docker_container" {
   provisioner "local-exec" {
-    command = "docker run --rm -e OIDC_CLIENT_PWD=${var.shared_secret_OIDC_CLIENT_PWD} -e INTERNAL_SECRET=${var.shared_secret_INTERNAL_SECRET} iamprajwal007/crypt-encrypt:latest > modules/cypher/n_client_secret.txt"
+    command = "docker run --rm -e OIDC_CLIENT_PWD=${var.shared_secret_OIDC_CLIENT_PWD} -e INTERNAL_SECRET=${var.shared_secret_INTERNAL_SECRET} indykite/3edges-crypt:latest > modules/cypher/n_client_secret.txt"
   }
 
   # Using the timestamp to trigger re-run on every apply

--- a/terraform/aws/modules/kubernetes/deployments/client/pods.tf
+++ b/terraform/aws/modules/kubernetes/deployments/client/pods.tf
@@ -23,7 +23,7 @@ resource "kubernetes_deployment" "deployment_dataproxy" {
       spec {
         container {
           name              = "${local.api_name}-proxy"
-          image             = "abotega/prim-dataproxy:hub"
+          image             = "indykite/3edges-dataproxy:latest"
           image_pull_policy = "Always"
 
           volume_mount {
@@ -84,7 +84,7 @@ resource "kubernetes_deployment" "deployment_authorization" {
       spec {
         container {
           name              = "${local.api_name}-authz"
-          image             = "abotega/prim-authorization:hub"
+          image             = "indykite/3edges-authorization:latest"
           image_pull_policy = "Always"
 
           volume_mount {
@@ -146,7 +146,7 @@ resource "kubernetes_deployment" "deployment_dashboard" {
       spec {
         container {
           name              = "${local.api_name}-dashboard"
-          image             = "abotega/prim-client-ui:hub"
+          image             = "indykite/3edges-dashboard:latest"
           image_pull_policy = "Always"
 
           volume_mount {
@@ -209,7 +209,7 @@ resource "kubernetes_deployment" "deployment_client_idp" {
       spec {
         container {
           name              = "${local.api_name}-idp"
-          image             = "abotega/prim-idp:hub"
+          image = "indykite/3edges-idp:latest"
           image_pull_policy = "Always"
 
           volume_mount {

--- a/terraform/aws/modules/kubernetes/deployments/ingress.tf
+++ b/terraform/aws/modules/kubernetes/deployments/ingress.tf
@@ -13,7 +13,7 @@ resource "kubernetes_ingress_v1" "three_edges_ingress" {
 
     tls {
       hosts       = [var.hosted_zone, "*.${var.hosted_zone}"]
-      secret_name = "letsencrypt-wildcard-secret"
+      secret_name = var.use_client_cert ? var.client_cert_secret_name : "letsencrypt-wildcard-secret"
     }
 
     rule {

--- a/terraform/aws/modules/kubernetes/deployments/pods.tf
+++ b/terraform/aws/modules/kubernetes/deployments/pods.tf
@@ -22,8 +22,8 @@ resource "kubernetes_deployment" "deployment_configuration" {
 
       spec {
         container {
-          name = "configuration"
-          image             = "abotega/prim-configuration:hub"
+          name              = "configuration"
+          image             = "indykite/3edges-configuration:latest"
           image_pull_policy = "Always"
 
           env_from {
@@ -63,14 +63,14 @@ resource "kubernetes_deployment" "deployment_dataloader_ui" {
     template {
       metadata {
         labels = {
-          app  = "dataloader-ui"
+          app = "dataloader-ui"
         }
       }
 
       spec {
         container {
           name              = "dataloader-ui"
-          image             = "abotega/prim-dataloader-ui:hub"
+          image = "indykite/3edges-webloader:latest"
           image_pull_policy = "Always"
 
           env_from {
@@ -104,14 +104,14 @@ resource "kubernetes_deployment" "deployment_dataloader" {
     template {
       metadata {
         labels = {
-          app  = "dataloader"
+          app = "dataloader"
         }
       }
 
       spec {
         container {
           name              = "dataloader"
-          image             = "abotega/prim-dataloader:hub"
+          image = "indykite/3edges-dataloader:latest"
           image_pull_policy = "Always"
 
           env_from {
@@ -151,14 +151,14 @@ resource "kubernetes_deployment" "deployment_cluster" {
     template {
       metadata {
         labels = {
-          app  = "cluster"
+          app = "cluster"
         }
       }
 
       spec {
         container {
           name              = "cluster"
-          image             = "abotega/prim-cluster:hub"
+          image = "indykite/3edges-cluster:latest"
           image_pull_policy = "Always"
 
           env_from {
@@ -199,14 +199,14 @@ resource "kubernetes_deployment" "deployment_idp" {
     template {
       metadata {
         labels = {
-          app  = "idp"
+          app = "idp"
         }
       }
 
       spec {
         container {
           name              = "idp"
-          image             = "abotega/prim-idp:hub"
+          image = "indykite/3edges-idp:latest"
           image_pull_policy = "Always"
 
           env_from {
@@ -252,8 +252,8 @@ resource "kubernetes_deployment" "deployment_ui" {
 
       spec {
         container {
-          name              = "ui"
-          image             = "abotega/prim-ui:hub"
+          name = "ui"
+          image             = "indykite/3edges-ui:latest"
           image_pull_policy = "Always"
 
           env_from {

--- a/terraform/aws/modules/kubernetes/deployments/secrets.tf
+++ b/terraform/aws/modules/kubernetes/deployments/secrets.tf
@@ -91,3 +91,19 @@ resource "kubernetes_secret" "ui_secrets" {
 
   depends_on = [ var.kubernetes_namespace_namespace ]
 }
+
+# This is the secret for storing client certificate 
+resource "kubernetes_secret" "client_cert_secret" {
+  count = var.use_client_cert ? 1 : 0  # Only create the secret if the client provides a cert
+
+  metadata {
+    name = var.client_cert_secret_name
+  }
+
+  data = {
+    "tls.crt" = file(var.client_cert_file)  # The certificate file provided by the client
+    "tls.key" = file(var.client_key_file)   # The corresponding private key
+  }
+
+  type = "kubernetes.io/tls"
+}

--- a/terraform/aws/modules/kubernetes/deployments/variables.tf
+++ b/terraform/aws/modules/kubernetes/deployments/variables.tf
@@ -406,3 +406,11 @@ variable "api_name" {}
 variable "PROM_METRICS_PREFIX" {}
 
 variable "manual_api_deployment" {}
+
+variable "use_client_cert" {}
+
+variable "client_cert_secret_name" {}
+
+variable "client_cert_file" {}
+
+variable "client_key_file" {}

--- a/terraform/aws/modules/kubernetes/variables.tf
+++ b/terraform/aws/modules/kubernetes/variables.tf
@@ -412,3 +412,15 @@ variable "api_name" {}
 variable "PROM_METRICS_PREFIX" {}
 
 variable "manual_api_deployment" {}
+
+variable "root_domain" {}
+
+variable "is_root_domain" {}
+
+variable "use_client_cert" {}
+
+variable "client_cert_secret_name" {}
+
+variable "client_cert_file" {}
+
+variable "client_key_file" {}

--- a/terraform/aws/terraform.tfvars
+++ b/terraform/aws/terraform.tfvars
@@ -88,7 +88,7 @@ ui_secret_REACT_APP_CAPTCHA_V2 = "your_captcha_v2"
 idp_config_SOCIAL_GOOGLE_CLIENT_ID = "your-idp-config-social-google-client-id"
 
 # Manual 3Edges Client API deployment (true or false)
-manual_api_deployment = false 
+manual_api_deployment = false
 
 # Whether the client provides their own cert (true or false)
 use_client_cert = false

--- a/terraform/aws/terraform.tfvars
+++ b/terraform/aws/terraform.tfvars
@@ -89,3 +89,15 @@ idp_config_SOCIAL_GOOGLE_CLIENT_ID = "your-idp-config-social-google-client-id"
 
 # Manual 3Edges Client API deployment (true or false)
 manual_api_deployment = false 
+
+# Whether the client provides their own cert (true or false)
+use_client_cert = false
+
+# Name of the Kubernetes secret where the cert is stored
+client_cert_secret_name = "your-client-cert-secret"
+
+# Path to the cert file provided by the client
+client_cert_file = "absolute-path/to/client-cert.pem"
+
+# Path to the private key file provided by the client
+client_key_file = "absolute-path/to/client-key.pem"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1191,3 +1191,39 @@ variable "manual_api_deployment" {
   default     = false
   type        = bool
 }
+
+variable "root_domain" {
+  description = "This variable is used to extract the  root domain"
+  default     = ""
+  type        = string
+}
+
+variable "is_root_domain" {
+  description = "This variable is used check if its a root domain"
+  default     = ""
+  type        = string
+}
+
+variable "use_client_cert" {
+  description = "Whether the client provides their own cert"
+  default     = false
+  type        = bool
+}
+
+variable "client_cert_secret_name" {
+  description = "Name of the Kubernetes secret where the cert is stored"
+  default     = ""
+  type        = string
+}
+
+variable "client_cert_file" {
+  description = "Path to the cert file provided by the client"
+  default     = ""
+  type        = string
+}
+
+variable "client_key_file" {
+  description = "Path to the private key file provided by the client"
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
# SUMMARY

This PR is for the task, 

PRIM-3304 : Apply 3edges on subdomain and check certificate. 

I have also updated the docker image repository with the [IndyKite](https://hub.docker.com/u/indykite) Dockerhub

# TEST PLAN
* For subdomains : You can provide subdomain for "hosted_zone" in the terraform.tfvars file. Only pre-requisite is you should already be having a hosted_zone for you root domain in AWS Route 53 

* For docker image source : You could search for image value in the project or after deployment you could check the pods image value in the Lens IDE
